### PR TITLE
Use pathlib instead of os.path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: Python
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build_python:
+
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.9", "3.10", "3.11.0-rc.2"]
+
+    runs-on: ${{matrix.runner}}
+    name: OS ${{matrix.runner}} Python ${{matrix.python-version}}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        pip install -e .
+        pip install pytest
+
+    - name: Check Python version
+      run: python -V
+
+    - name: Test with pytest
+      run: pytest -vs
+

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,4 @@
+
+def pytest_addoption(parser):
+    parser.addoption("--save", action='store_true')
+

--- a/examples/01-basic/input/content/index.html
+++ b/examples/01-basic/input/content/index.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1>Head 1</h1>
+{% endblock %}

--- a/examples/01-basic/input/templates/base.html
+++ b/examples/01-basic/input/templates/base.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+	<head>
+	</head>
+	<body>
+		<h1>Title</h1>
+		<p>Content:</p>
+		{% block content %} {% endblock %}
+	</body>
+</html>

--- a/examples/01-basic/output/index.html
+++ b/examples/01-basic/output/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+	<head>
+	</head>
+	<body>
+		<h1>Title</h1>
+		<p>Content:</p>
+<h1>Head 1</h1>
+	</body>
+</html>

--- a/examples/02-one-page/input/content/index.html
+++ b/examples/02-one-page/input/content/index.html
@@ -4,7 +4,7 @@
 <h1>Head 1</h1>
 
 <ul>
-	{% for page in pages %}
+	{% for page in pages|sort(attribute='name') %}
 	<li><a href="{{ page.href }}">{{ page.name }}</a></li>
 	{% endfor %}
 </ul>

--- a/examples/02-one-page/input/content/index.html
+++ b/examples/02-one-page/input/content/index.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1>Head 1</h1>
+
+<ul>
+	{% for page in pages %}
+	<li><a href="{{ page.href }}">{{ page.name }}</a></li>
+	{% endfor %}
+</ul>
+
+{% endblock %}

--- a/examples/02-one-page/input/content/post/first.md
+++ b/examples/02-one-page/input/content/post/first.md
@@ -1,0 +1,3 @@
+# First
+
+This is the first post

--- a/examples/02-one-page/input/templates/base.html
+++ b/examples/02-one-page/input/templates/base.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+	<head>
+	</head>
+	<body>
+		<h1>Base Title</h1>
+		<p>Content:</p>
+		{% block content %} {% endblock %}
+	</body>
+</html>

--- a/examples/02-one-page/input/templates/post.html
+++ b/examples/02-one-page/input/templates/post.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+<h2>Markdow</h2>
+<main>
+{{ markdown }}
+</main>
+
+
+<h2>plain text</h2>
+<pre>
+{{ plain_text|e }}
+</pre>
+
+{% endblock %}

--- a/examples/02-one-page/output/index.html
+++ b/examples/02-one-page/output/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html>
+	<head>
+	</head>
+	<body>
+		<h1>Base Title</h1>
+		<p>Content:</p>
+<h1>Head 1</h1>
+
+<ul>
+	<li><a href="index.html">index.html</a></li>
+	<li><a href="post/first.html">first.html</a></li>
+</ul>
+
+	</body>
+</html>

--- a/examples/02-one-page/output/index.html
+++ b/examples/02-one-page/output/index.html
@@ -8,8 +8,8 @@
 <h1>Head 1</h1>
 
 <ul>
-	<li><a href="index.html">index.html</a></li>
 	<li><a href="post/first.html">first.html</a></li>
+	<li><a href="index.html">index.html</a></li>
 </ul>
 
 	</body>

--- a/examples/02-one-page/output/post/first.html
+++ b/examples/02-one-page/output/post/first.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html>
+	<head>
+	</head>
+	<body>
+		<h1>Base Title</h1>
+		<p>Content:</p>
+
+<h2>Markdow</h2>
+<main>
+<h1 id="first">First</h1>
+<p>This is the first post</p>
+</main>
+
+
+<h2>plain text</h2>
+<pre>
+First
+This is the first post
+</pre>
+
+	</body>
+</html>

--- a/test_examples.py
+++ b/test_examples.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import filecmp
+import difflib
 import shutil
 
 import pytest
@@ -9,12 +10,25 @@ import pytest
 root = os.path.dirname(__file__)
 examples = os.listdir(os.path.join(root, 'examples'))
 
-def check_diffs(dcmp):
+def check_diffs(dcmp, left, right):
     assert dcmp.left_only == []
     assert dcmp.right_only == []
-    assert dcmp.diff_files == []
+    success = True
+    for filename in dcmp.diff_files:
+        success = False
+        print(f"File with difference: {filename}")
+        with open(os.path.join(left, filename)) as fh:
+            left_content = fh.readlines()
+        with open(os.path.join(right, filename)) as fh:
+            right_content = fh.readlines()
+        for row in difflib.unified_diff(left_content, right_content):
+            print(row, end="")
+        print()
+
+    #assert dcmp.diff_files == []
     for sub_dcmp in dcmp.subdirs.values():
-        check_diffs(sub_dcmp)
+        success = success and check_diffs(sub_dcmp, left, right)
+    return success
 
 @pytest.mark.parametrize("example", examples)
 def test_examples(example, tmpdir, request):
@@ -35,5 +49,5 @@ def test_examples(example, tmpdir, request):
 
     dcmp = filecmp.dircmp(expected_output, outdir)
     print(expected_output, outdir)
-    check_diffs(dcmp)
+    assert check_diffs(dcmp, str(expected_output), str(outdir)), "Some files differ. See above using the -s flag of pytest"
 

--- a/test_examples.py
+++ b/test_examples.py
@@ -10,16 +10,17 @@ import pytest
 root = os.path.dirname(__file__)
 examples = os.listdir(os.path.join(root, 'examples'))
 
-def check_diffs(dcmp, left, right):
+def check_diffs(dcmp):
+    print(f'check_diffs {dcmp.left} and {dcmp.right}')
     assert dcmp.left_only == []
     assert dcmp.right_only == []
     success = True
     for filename in dcmp.diff_files:
         success = False
         print(f"File with difference: {filename}")
-        with open(os.path.join(left, filename)) as fh:
+        with open(os.path.join(dcmp.left, filename)) as fh:
             left_content = fh.readlines()
-        with open(os.path.join(right, filename)) as fh:
+        with open(os.path.join(dcmp.right, filename)) as fh:
             right_content = fh.readlines()
         for row in difflib.unified_diff(left_content, right_content):
             print(row, end="")
@@ -27,7 +28,7 @@ def check_diffs(dcmp, left, right):
 
     #assert dcmp.diff_files == []
     for sub_dcmp in dcmp.subdirs.values():
-        success = success and check_diffs(sub_dcmp, left, right)
+        success = check_diffs(sub_dcmp) and success
     return success
 
 @pytest.mark.parametrize("example", examples)
@@ -49,5 +50,5 @@ def test_examples(example, tmpdir, request):
 
     dcmp = filecmp.dircmp(expected_output, outdir)
     print(expected_output, outdir)
-    assert check_diffs(dcmp, str(expected_output), str(outdir)), "Some files differ. See above using the -s flag of pytest"
+    assert check_diffs(dcmp), "Some files differ. See above using the -s flag of pytest"
 

--- a/test_examples.py
+++ b/test_examples.py
@@ -1,0 +1,39 @@
+import os
+import sys
+import filecmp
+import shutil
+
+import pytest
+
+
+root = os.path.dirname(__file__)
+examples = os.listdir(os.path.join(root, 'examples'))
+
+def check_diffs(dcmp):
+    assert dcmp.left_only == []
+    assert dcmp.right_only == []
+    assert dcmp.diff_files == []
+    for sub_dcmp in dcmp.subdirs.values():
+        check_diffs(sub_dcmp)
+
+@pytest.mark.parametrize("example", examples)
+def test_examples(example, tmpdir, request):
+    print(example)
+    os.environ["PYTHONPATH"] = os.path.join(root, 'src')
+    outdir = os.path.join(tmpdir, 'out')
+    cmd = f"{sys.executable} -m sssimp --input {os.path.join(root, 'examples', example, 'input')} {outdir}"
+    print(cmd)
+    exit_code = os.system(cmd)
+    assert exit_code == 0
+    expected_output = os.path.join(root, 'examples', example, 'output')
+    save = request.config.getoption("--save")
+    if save:
+        if os.path.exists(expected_output):
+            shutil.rmtree(expected_output)
+        shutil.move(outdir, expected_output)
+        return
+
+    dcmp = filecmp.dircmp(expected_output, outdir)
+    print(expected_output, outdir)
+    check_diffs(dcmp)
+


### PR DESCRIPTION
I was avoiding pathlib earlier, but your suggestion promted me to look at it.
I am not sure I like the use of / instead of joinpath, (for one, it is harder to search for) but that seemed to be the more idiomatic code.